### PR TITLE
Fix a few loot items that break under 1.20.1

### DIFF
--- a/src/main/java/net/tigereye/spellbound/config/SBConfig.java
+++ b/src/main/java/net/tigereye/spellbound/config/SBConfig.java
@@ -728,6 +728,7 @@ public class SBConfig implements ConfigData {
         public int RARITY_OF_NEW_PLOTHOOKS = 2;
         public boolean CAN_CREATE_TREASURE = true;
         public boolean CAN_CREATE_CURSE = false;
+        public boolean CAN_CREATE_NON_LOOT = false;
 
     }
 

--- a/src/main/java/net/tigereye/spellbound/enchantments/meta/StoriedEnchantment.java
+++ b/src/main/java/net/tigereye/spellbound/enchantments/meta/StoriedEnchantment.java
@@ -193,6 +193,7 @@ public class StoriedEnchantment extends SBEnchantment {
                     && enchantment.getMaxLevel() > 0 //to prevent disabled enchantments from being rolled
                     && ((!enchantment.isCursed()) || Spellbound.config.storied.CAN_CREATE_CURSE)
                     && ((!enchantment.isTreasure()) || Spellbound.config.storied.CAN_CREATE_TREASURE)
+                    && ((enchantment.isAvailableForRandomSelection()) || Spellbound.config.storied.CAN_CREATE_NON_LOOT)
                     && enchantment.isAcceptableItem(stack))
             {
                 boolean noConflict = true;

--- a/src/main/resources/assets/spellbound/lang/en_us.yml
+++ b/src/main/resources/assets/spellbound/lang/en_us.yml
@@ -736,6 +736,9 @@ text.autoconfig.spellbound:
         storied.WORDS_PER_LEVEL_SECOND_DEGREE: Words Per Level Second Degree
         storied.ALLOW_NEW_PLOTHOOKS: Allow New Plothooks
         storied.RARITY_OF_NEW_PLOTHOOKS: Rarity Of New Plothooks
+        storied.CAN_CREATE_TREASURE: Can Add Treasure Enchantments
+        storied.CAN_CREATE_CURSE: Can Add Curses
+        storied.CAN_CREATE_NON_LOOT: Can Add Non-Loot Enchantments
         
         sunkenTreasure: Sunken Treasure
         sunkenTreasure.ENABLED: Enable

--- a/src/main/resources/data/spellbound/loot_tables/chests/end_decent_crate.json
+++ b/src/main/resources/data/spellbound/loot_tables/chests/end_decent_crate.json
@@ -43,7 +43,7 @@
         },
         {
           "type": "minecraft:loot_table",
-          "name": "spellbound:chests/random_pottery_shard",
+          "name": "spellbound:chests/random_pottery_sherd",
           "weight": 20
         }
       ],

--- a/src/main/resources/data/spellbound/loot_tables/chests/end_fantastic_crate.json
+++ b/src/main/resources/data/spellbound/loot_tables/chests/end_fantastic_crate.json
@@ -6,7 +6,7 @@
       "entries": [
         {
           "type": "minecraft:loot_table",
-          "name": "spellbound:chests/random_pottery_shard",
+          "name": "spellbound:chests/random_pottery_sherd",
           "weight": 50
         },
         {

--- a/src/main/resources/data/spellbound/loot_tables/chests/end_good_crate.json
+++ b/src/main/resources/data/spellbound/loot_tables/chests/end_good_crate.json
@@ -22,7 +22,7 @@
         },
         {
           "type": "minecraft:loot_table",
-          "name": "spellbound:chests/random_pottery_shard",
+          "name": "spellbound:chests/random_pottery_sherd",
           "weight": 80
         },
         {

--- a/src/main/resources/data/spellbound/loot_tables/chests/end_great_crate.json
+++ b/src/main/resources/data/spellbound/loot_tables/chests/end_great_crate.json
@@ -6,7 +6,7 @@
       "entries": [
         {
           "type": "minecraft:loot_table",
-          "name": "spellbound:chests/random_pottery_shard",
+          "name": "spellbound:chests/random_pottery_sherd",
           "weight": 80
         },
         {

--- a/src/main/resources/data/spellbound/loot_tables/chests/end_junk_crate.json
+++ b/src/main/resources/data/spellbound/loot_tables/chests/end_junk_crate.json
@@ -17,7 +17,7 @@
               "function": "minecraft:set_count"
             }
           ],
-          "name": "minecraft:enderpearl",
+          "name": "minecraft:ender_pearl",
           "weight": 30
         },
         {
@@ -54,83 +54,83 @@
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:angler_pottery_shard"
+          "name": "minecraft:angler_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:archer_pottery_shard"
+          "name": "minecraft:archer_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:arms_up_pottery_shard"
+          "name": "minecraft:arms_up_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:blade_pottery_shard"
+          "name": "minecraft:blade_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:brewer_pottery_shard"
+          "name": "minecraft:brewer_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:burn_pottery_shard"
+          "name": "minecraft:burn_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:danger_pottery_shard"
+          "name": "minecraft:danger_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:explorer_pottery_shard"
+          "name": "minecraft:explorer_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:friend_pottery_shard"
+          "name": "minecraft:friend_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:heart_pottery_shard"
+          "name": "minecraft:heart_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:heartbreak_pottery_shard"
+          "name": "minecraft:heartbreak_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:howl_pottery_shard"
+          "name": "minecraft:howl_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:miner_pottery_shard"
+          "name": "minecraft:miner_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:mourner_pottery_shard"
+          "name": "minecraft:mourner_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:plenty_pottery_shard"
+          "name": "minecraft:plenty_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:prize_pottery_shard"
+          "name": "minecraft:prize_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:sheaf_pottery_shard"
+          "name": "minecraft:sheaf_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:shelter_pottery_shard"
+          "name": "minecraft:shelter_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:skull_pottery_shard"
+          "name": "minecraft:skull_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:snort_pottery_shard"
+          "name": "minecraft:snort_pottery_sherd"
         }
       ],
       "rolls": {

--- a/src/main/resources/data/spellbound/loot_tables/chests/random_pottery_sherd.json
+++ b/src/main/resources/data/spellbound/loot_tables/chests/random_pottery_sherd.json
@@ -6,83 +6,83 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:angler_pottery_shard"
+          "name": "minecraft:angler_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:archer_pottery_shard"
+          "name": "minecraft:archer_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:arms_up_pottery_shard"
+          "name": "minecraft:arms_up_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:blade_pottery_shard"
+          "name": "minecraft:blade_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:brewer_pottery_shard"
+          "name": "minecraft:brewer_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:burn_pottery_shard"
+          "name": "minecraft:burn_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:danger_pottery_shard"
+          "name": "minecraft:danger_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:explorer_pottery_shard"
+          "name": "minecraft:explorer_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:friend_pottery_shard"
+          "name": "minecraft:friend_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:heart_pottery_shard"
+          "name": "minecraft:heart_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:heartbreak_pottery_shard"
+          "name": "minecraft:heartbreak_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:howl_pottery_shard"
+          "name": "minecraft:howl_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:miner_pottery_shard"
+          "name": "minecraft:miner_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:mourner_pottery_shard"
+          "name": "minecraft:mourner_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:plenty_pottery_shard"
+          "name": "minecraft:plenty_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:prize_pottery_shard"
+          "name": "minecraft:prize_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:sheaf_pottery_shard"
+          "name": "minecraft:sheaf_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:shelter_pottery_shard"
+          "name": "minecraft:shelter_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:skull_pottery_shard"
+          "name": "minecraft:skull_pottery_sherd"
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:snort_pottery_shard"
+          "name": "minecraft:snort_pottery_sherd"
         }
       ],
       "rolls": 1.0

--- a/src/main/resources/data/spellbound/loot_tables/chests/random_smithing_template.json
+++ b/src/main/resources/data/spellbound/loot_tables/chests/random_smithing_template.json
@@ -50,14 +50,6 @@
         },
         {
           "type": "minecraft:item",
-          "name": "minecraft:flow_armor_trim_smithing_template"
-        },
-        {
-          "type": "minecraft:item",
-          "name": "minecraft:bolt_armor_trim_smithing_template"
-        },
-        {
-          "type": "minecraft:item",
           "name": "minecraft:wayfinder_armor_trim_smithing_template"
         },
         {


### PR DESCRIPTION
* pottery_shard -> pottery_sherd
* enderpearl -> ender_pearl
* bolt and flow armor trims don't exist in vanilla 1.20.1